### PR TITLE
deps: fix async call

### DIFF
--- a/cyberhobo.js
+++ b/cyberhobo.js
@@ -8,6 +8,7 @@ var mkdirp = require('mkdirp')
 var once = require('once')
 var path = require('path')
 var series = require('run-series')
+var waterfall = require('run-waterfall')
 
 var COMMANDS = {
   git: ['push'],
@@ -37,11 +38,9 @@ function run (argv, cwd, cb) {
   child.on('error', cb)
 }
 
-
 var argv = process.argv.slice(2)
 
-series.waterfall([
-
+waterfall([
   // Ensure that the data folder exists
   function (cb) {
     mkdirp(DATA_DIR, function (err) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "connectivity": "^0.1.1",
     "mkdirp": "^0.5.0",
     "once": "^1.3.0",
-    "run-series": "^1.0.2"
+    "run-series": "^1.0.2",
+    "run-waterfall": "^1.1.2"
   },
   "homepage": "https://github.com/feross/cyberhobo/",
   "keywords": [


### PR DESCRIPTION
Noticed the `cyberhobo` command wasn't working, this should fix it. Thanks!
## Changes
- **deps**: replace dead `series.waterfall` call with `run-waterfall`
